### PR TITLE
Upgraded chokidar

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -5,6 +5,13 @@ var colors = require('colors'),
     portfinder = require('portfinder'),
     opener = require('opener'),
     argv = require('optimist')
+      .boolean('d')
+      .boolean('i')
+      .boolean('o')
+      .boolean('s')
+      .boolean('S')
+      .boolean('ssl')
+      .boolean('ext')
       .boolean('cors')
       .argv;
 
@@ -78,6 +85,8 @@ function listen(port) {
       key: argv.K || argv.key || 'key.pem'
     };
   }
+
+  // console.log(`Sexstatic options ${JSON.stringify(options, null, 2)}`);
 
   var server = httpServer.createServer(options);
   server.listen(port, host, function() {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "chokidar": "^2.0.4",
     "colors": "1.0.3",
-    "sexstatic": "~0.6.x",
+    "sexstatic": "git+https://JamesMcIntosh@github.com/JamesMcIntosh/node-sexstatic#30327c8a82a9f63592977f1a3fe82b1a10d6cecf",
     "opener": "~1.4.0",
     "optimist": "0.6.x",
     "portfinder": "0.2.x",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     }
   ],
   "dependencies": {
-    "chokidar": "^0.12.4",
+    "chokidar": "^2.0.4",
     "colors": "1.0.3",
     "sexstatic": "~0.6.x",
     "opener": "~1.4.0",


### PR DESCRIPTION
When running in some projects I get the following error caused by an outdated version of fsevents in as a transitive dependency of `chokidar`.

```
# Fatal error in , line 0
# Check failed: !value_obj->IsJSReceiver() || value_obj->IsTemplateInfo().
#FailureMessage Object: 0x7ffeefbfbd30Illegal instruction: 4
```

I think this is the check it is failing.
https://github.com/v8/v8/commit/eebdee8eafa97849cc70c25f3fecf1b075bac248

Simply updating the dependency fixes the problem.